### PR TITLE
Quick fix for: Initial discovery of Gateways works fine, but when starting the integration with all gateways configured it can't find any gateway

### DIFF
--- a/custom_components/mobile_alerts/__init__.py
+++ b/custom_components/mobile_alerts/__init__.py
@@ -27,7 +27,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Mobile-Alerts from a config entry."""
     _LOGGER.debug("async_setup_entry %r", entry.as_dict())
 
-    gateway = Gateway(entry.unique_id)
+    local_ip = await async_get_source_ip(hass)
+    gateway = Gateway(entry.unique_id, local_ip)
     gateway.send_data_to_cloud = entry.options.get(CONF_SEND_DATA_TO_CLOUD, True)
     if not await gateway.init():
         raise ConfigEntryNotReady("Error initialization of MobileAlerts Gateway (%s)", gateway.gateway_id)


### PR DESCRIPTION
This closes #26 

Hi @Iminet72, this is the "quick fix" to make at least the configuration of the discovered gateway on startup using the same source address like the initial discovery.

It works for me, but the fix here is not working well if a user has multiple interfaces enabled in HASS network configuration. Basically for every enabled network interface (enabled in HASS config), the code needs to send a separate discovery or update request to the corresponding broadcast address of the network interface.

For this both code parts need to be a loop:
- discovery needs to collect all gateways (e.g., possible those in the guest/DMZ LAN and others in the private network. Of course they should not look into WAN interfaces. All found gateways must be added to the final list
- when configuring a specific interface, the broadcast must be sent to all interfaces and the method must return true, if at least one gateway with the given ID responds about the reconfiguration or has returned its config.

I will check tomorrow and possibly open another PR to fix the discovery "correctly" - like it is done in HASS core code (for discovery of several device types like shelly components, yeelight). They use always the same pattern, e.g. here for shelly devices:

https://github.com/home-assistant/core/blob/94534f714cf4f2e5cecc6c1d569609325a1d08da/homeassistant/components/shelly/utils.py#L225-L241

So basically the code must look like this - for discovery and also for configuring a single gateway (as we do not know where is it connected at and communication to gateway only works via broadcast).
