### PR TITLE
Ha frozen dataclass support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+## [0.1.4] - 2025-07-10
+
+### Changed
+
+Fix compatibility with frozen dataclasses for Home Assistant 2024.x
+
+- Refactor entity descriptions to use dataclasses.replace instead of direct attribute assignment
+- Prevent FrozenInstanceError on Sensor and BinarySensor entities
+- Clean up legacy code and ensure compatibility with latest Home Assistant core
+
 ## [0.1.3] - 2023-04-20
 
 ### Changed

--- a/custom_components/mobile_alerts/binary_sensor.py
+++ b/custom_components/mobile_alerts/binary_sensor.py
@@ -19,6 +19,8 @@ from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from mobilealerts import Gateway, Measurement, MeasurementType, Sensor
 
+from dataclasses import replace
+
 from .base import MobileAlertesBaseCoordinator, MobileAlertesEntity
 from .const import BINARY_MEASUREMENT_TYPES, DOMAIN, LAST_RAIN_PERIOD
 from .sensor import MobileAlertesSensor
@@ -76,7 +78,7 @@ class MobileAlertesGatewayBinarySensor(BinarySensorEntity):
         """Initialize the sensor."""
         super().__init__()
         self._gateway = gateway
-        description.translation_key = description.key
+        #description.translation_key = description.key
         self.entity_description = description
         self._attr_has_entity_name = True
         self._attr_device_class = None
@@ -112,8 +114,11 @@ class MobileAlertesBinarySensor(MobileAlertesEntity, BinarySensorEntity):
                 measurement.name.lower().replace(" ", "_").replace("/", "_")
             )
 
+        #if description is not None and description.translation_key is None:
+        #    description.translation_key = description.key
+
         if description is not None and description.translation_key is None:
-            description.translation_key = description.key
+            description = replace(description, translation_key=description.key)
 
         _LOGGER.debug("translation_key %s", description.translation_key)
 


### PR DESCRIPTION
Fix compatibility with frozen dataclasses for Home Assistant 2024.x

- Refactor entity descriptions to use dataclasses.replace instead of direct attribute assignment
- Prevent FrozenInstanceError on Sensor and BinarySensor entities
- Clean up legacy code and ensure compatibility with latest Home Assistant core